### PR TITLE
Use a pre-built Docker image base

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -25,23 +25,34 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: test Dockerfiles
+      - name: test main Dockerfile
+        run: make image
+      - name: test fetch.py in container
+        env:
+          GHRS_GITHUB_API_TOKEN: ${{ secrets.ghrs_github_api_token }}
+        run: |
+          docker run \
+            --entrypoint "/bin/bash" \
+            -e GHRS_GITHUB_API_TOKEN \
+            -v $(pwd):/cwd \
+            jgehrcke/github-repo-stats:local -c \
+            'set -o errexit && cd /cwd
+             python fetch.py jgehrcke/github-repo-stats
+            '
+      - name: test analyze.py in container
+        env:
+          GHRS_GITHUB_API_TOKEN: ${{ secrets.ghrs_github_api_token }}
+        run: |
+          docker run \
+            --entrypoint "/bin/bash" \
+            -e GHRS_GITHUB_API_TOKEN \
+            -v $(pwd):/cwd \
+            jgehrcke/github-repo-stats:local -c \
+            'set -o errexit && cd /cwd
+              python fetch.py jgehrcke/github-repo-stats
+              python analyze.py jgehrcke/github-repo-stats _ghrs_jgehrcke_github-repo-stats
+              cat *_report/*_report.md
+            '
+      - name: test base image Dockerfile
         run: |
           make base-image
-          make image
-      - name: test fetch.py
-        env:
-          GHRS_GITHUB_API_TOKEN: ${{ secrets.ghrs_github_api_token }}
-        run: |
-          pip install pandas==1.2.1 PyGitHub==1.54 pytz retrying
-          python fetch.py jgehrcke/github-repo-stats
-      - name: test analyze.py
-        env:
-          GHRS_GITHUB_API_TOKEN: ${{ secrets.ghrs_github_api_token }}
-        run: |
-          pip install pandas==1.2.1 PyGitHub==1.54 pytz retrying
-          python fetch.py jgehrcke/github-repo-stats
-          pip install carbonplan[styles] altair
-          sudo apt-get install pandoc
-          python analyze.py jgehrcke/github-repo-stats _ghrs_jgehrcke_github-repo-stats
-          cat *_report/*_report.md

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -25,6 +25,10 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: test Dockerfiles
+        run: |
+          make base-image
+          make image
       - name: test fetch.py
         env:
           GHRS_GITHUB_API_TOKEN: ${{ secrets.ghrs_github_api_token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,6 @@ RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" 
 RUN apt-get -y update
 RUN apt-get -y install google-chrome-stable
 
-# RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
-#     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-# RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-#     apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-# RUN apt-get update && apt-get install -y -q --no-install-recommends google-cloud-sdk
-# RUN apt-get -y autoclean
-
-# RUN gcloud config set core/disable_usage_reporting true && \
-#     gcloud config set component_manager/disable_update_check true && \
-#     gcloud config set metrics/environment github_docker_image
-
-# RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-#     unzip -q awscliv2.zip && \
-#     ./aws/install && \
-#     rm awscliv2.zip
-
 RUN pip install pandas==1.2.4 PyGitHub==1.54.1 pytz retrying \
     selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" 
 RUN apt-get -y update
 RUN apt-get -y install google-chrome-stable
 
-RUN pip install pandas==1.2.4 PyGitHub==1.54.1 pytz retrying \
+RUN pip install pandas==1.3.2 PyGitHub==1.54.1 pytz retrying \
     selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.1.0
 
 COPY fetch.py /fetch.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM python:3.8-slim-buster
-
-RUN apt-get update && apt-get install -y -q --no-install-recommends \
-    gnupg curl git jq moreutils ca-certificates unzip less tree pandoc
-
-RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
-RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-RUN apt-get -y update
-RUN apt-get -y install google-chrome-stable
-
-RUN pip install pandas==1.3.2 PyGitHub==1.54.1 pytz retrying \
-    selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.1.0
+FROM jgehrcke/github-repo-stats-base:9dec0ebaf
 
 COPY fetch.py /fetch.py
 COPY analyze.py /analyze.py

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 GIT_COMMIT_HASH ?= $(shell git rev-parse --short=9 HEAD)
 
-IMAGE_NAME = jgehrcke/github-repo-stats:$(GIT_COMMIT_HASH)
+IMAGE_NAME = jgehrcke/github-repo-stats-base:$(GIT_COMMIT_HASH)
 
-image:
-	docker build -f Dockerfile . -t $(IMAGE_NAME)
+base-image:
+	docker build -f base.Dockerfile . -t $(IMAGE_NAME)
 
-image-push:
+base-image-push:
 	docker push $(IMAGE_NAME)
+
+# This is for testing the container image build based on Dockerfile, as
+# executed by GH actions.
+image:
+	docker build -f Dockerfile . -t jgehrcke/github-repo-stats

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+GIT_COMMIT_HASH ?= $(shell git rev-parse --short=9 HEAD)
+
+IMAGE_NAME = jgehrcke/github-repo-stats:$(GIT_COMMIT_HASH)
+
+image:
+	docker build -f Dockerfile . -t $(IMAGE_NAME)
+
+image-push:
+	docker push $(IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ base-image-push:
 # This is for testing the container image build based on Dockerfile, as
 # executed by GH actions.
 image:
-	docker build -f Dockerfile . -t jgehrcke/github-repo-stats
+	docker build -f Dockerfile . -t jgehrcke/github-repo-stats:local

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim-buster
+
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    gnupg curl git jq moreutils ca-certificates unzip less tree pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
+RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get -y update
+RUN apt-get -y install google-chrome-stable
+
+RUN pip install pandas==1.3.2 PyGitHub==1.54.1 pytz retrying \
+    selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.1.0


### PR DESCRIPTION
The Docker image build is rather heavy, and executed on every single GH actions run.

With this change, the `Dockerfile` in this repo uses a new image base: https://hub.docker.com/r/jgehrcke/github-repo-stats-base

This includes
- the Chrome installation and
- the heavy Python dependencies

Now we're not following `python:3.8-slim-buster` as a moving target anymore. This is often a red flag in security-critical environments. But not so much here. It's fine when the base gets a little out of date with the upstream Linux distro every now and then.

This approach / patch / PR is motivated by https://github.com/jgehrcke/github-repo-stats/issues/24 and also my own observations where the Docker image build sometimes fails as of instabilities. 
