### PR TITLE
Report cumulative stats on clones and views

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -37,7 +37,7 @@ jobs:
             -v $(pwd):/cwd \
             jgehrcke/github-repo-stats:local -c \
             'set -o errexit && cd /cwd
-             python fetch.py jgehrcke/github-repo-stats
+             python fetch.py iqcToolbox/iqcToolbox
             '
       - name: test analyze.py in container
         env:
@@ -49,8 +49,8 @@ jobs:
             -v $(pwd):/cwd \
             jgehrcke/github-repo-stats:local -c \
             'set -o errexit && cd /cwd
-              python fetch.py jgehrcke/github-repo-stats
-              python analyze.py jgehrcke/github-repo-stats _ghrs_jgehrcke_github-repo-stats
+              python fetch.py iqctoolbox/iqctoolbox
+              python analyze.py iqcToolbox/iqcToolbox _ghrs_iqctoolbox_github-repo-stats
               cat *_report/*_report.md
             '
       - name: test base image Dockerfile

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -37,7 +37,7 @@ jobs:
             -v $(pwd):/cwd \
             jgehrcke/github-repo-stats:local -c \
             'set -o errexit && cd /cwd
-             python fetch.py iqcToolbox/iqcToolbox
+             python fetch.py jgehrcke/github-repo-stats
             '
       - name: test analyze.py in container
         env:
@@ -49,8 +49,8 @@ jobs:
             -v $(pwd):/cwd \
             jgehrcke/github-repo-stats:local -c \
             'set -o errexit && cd /cwd
-              python fetch.py iqctoolbox/iqctoolbox
-              python analyze.py iqcToolbox/iqcToolbox _ghrs_iqctoolbox_github-repo-stats
+              python fetch.py jgehrcke/github-repo-stats
+              python analyze.py jgehrcke/github-repo-stats _ghrs_jgehrcke_github-repo-stats
               cat *_report/*_report.md
             '
       - name: test base image Dockerfile


### PR DESCRIPTION
This PR changes `analyze.py` in order to produce reports that include cumulative graphs on the unique/total views/clones.