### PR TITLE
Fix exit on errexit when return code is used for checks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,12 +38,15 @@ DATA_BRANCH_NAME="${INPUT_DATABRANCH}"
 echo "length of API TOKEN: ${#GHRS_GITHUB_API_TOKEN}"
 
 set -x
+set +e
 # Clone / check out specific branch only (to minimize overhead, also see
 # https://stackoverflow.com/a/4568323/145400).
 # git clone -b "${DATA_BRANCH_NAME}" \
 #     --single-branch git@github.com:${REPOSPEC}.git
 git ls-remote --exit-code --heads https://ghactions:${GHRS_GITHUB_API_TOKEN}@github.com/${DATA_REPOSPEC}.git "${DATA_BRANCH_NAME}"
-if [ $? -eq 2 ]; then
+LS_ECODE=$?
+set -e
+if [ $LS_ECODE -eq 2 ]; then
     # DATA_BRANCH_NAME branch doesn't exists, create a new one
     git clone https://ghactions:${GHRS_GITHUB_API_TOKEN}@github.com/${DATA_REPOSPEC}.git .
     git remote set-url origin https://ghactions:${GHRS_GITHUB_API_TOKEN}@github.com/${DATA_REPOSPEC}.git


### PR DESCRIPTION
At the beginning of the script, the return code of `git ls-remote`
is used in a check while `errexit` is active. This does not work
because in case the `git ls-remote` returns a non-zero code, the
script will exit immediately and the line checking the return code
in an `if` clause is never reached.

For this to work, `errexit` needs to be temporarily disabled and
the return code stored in a variable for later use.