### PR TITLE
Fix #36, improve style, align time ranges, and misc

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -807,7 +807,8 @@ def analyse_view_clones_ts_fragments():
         log.info("pd.concat(dfs)")
         df_allsnapshots = pd.concat(dfs)
 
-        # combine the result of combine-all-snapshots with previous aggregate
+        # Combine the result of combine-all-snapshots with previous aggregate
+        dfall = df_allsnapshots
         if df_prev_agg is not None:
             if set(df_prev_agg.columns) != set(df_allsnapshots.columns):
                 log.error(

--- a/analyze.py
+++ b/analyze.py
@@ -586,7 +586,7 @@ def analyse_top_x_snapshots(entity_type):
                 sort=alt.SortField("order"),
             ),
         )
-        .configure_point(size=50)
+        .configure_point(size=30)
         .properties(**panel_props)
     )
 
@@ -869,7 +869,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=100)
+        .configure_point(size=40)
         .properties(**panel_props)
     )
 
@@ -891,7 +891,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=100)
+        .configure_point(size=40)
         .properties(**panel_props)
     )
 
@@ -913,7 +913,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=100)
+        .configure_point(size=40)
         .properties(**panel_props)
     )
 
@@ -935,7 +935,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=100)
+        .configure_point(size=40)
         .properties(**panel_props)
     )
 
@@ -1011,7 +1011,7 @@ def add_stargazers_section(df, date_axis_lim):
                 ),
             ),
         )
-        .configure_point(size=100)
+        .configure_point(size=50)
         .properties(**panel_props)
     )
 
@@ -1067,7 +1067,7 @@ def add_fork_section(df, date_axis_lim):
                 ),
             ),
         )
-        .configure_point(size=100)
+        .configure_point(size=50)
         .properties(**panel_props)
     )
 

--- a/analyze.py
+++ b/analyze.py
@@ -595,6 +595,15 @@ def analyse_top_x_snapshots(entity_type):
                 entity_type,
                 type="nominal",
                 sort=alt.SortField("order"),
+                # https://vega.github.io/vega-lite/docs/legend.html#legend-properties
+                legend={
+                    #"orient": "bottom",
+                    "orient": "top",
+                    "direction": "vertical",
+                    # "legendX": 120,
+                    # "legendY": 340,
+                    "title": "Legend:"
+                } ,
             ),
         )
         .configure_point(size=30)

--- a/analyze.py
+++ b/analyze.py
@@ -1167,7 +1167,7 @@ def get_stars_over_time():
         # reliably.
         df_for_csv_file = resample_to_1d_resolution(df, "stars_cumulative").astype(int)
         log.info("stars_cumulative, for CSV file (resampled): %s", df_for_csv_file)
-        log.info("write aggregate to %s", ARGS.views_clones_aggregate_outpath)
+        log.info("write aggregate to %s", ARGS.stargazer_ts_resampled_outpath)
         # Pragmatic strategy against partial write / encoding problems.
         tpath = ARGS.stargazer_ts_resampled_outpath + ".tmp"
         df_for_csv_file.to_csv(tpath, index_label="time_iso8601")

--- a/analyze.py
+++ b/analyze.py
@@ -580,7 +580,23 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
         log.info("custom time window for top %s plot: %s", entity_type, date_axis_lim)
         x_kwargs["scale"] = alt.Scale(domain=date_axis_lim)
 
-    panel_props = {"height": 300, "width": "container", "padding": 10}
+
+
+    # field=entity_type means for example `field="referrer"`. The melted data
+    # frame then has a column titled "referrer" with various values, for
+    # example "linkedin.com".
+    # selection_single_nearest = alt.selection_single(on='mouseover', nearest=True, field=entity_type)
+
+    panel_props = {
+        "height": 300,
+        "width": "container",
+        "padding": 10,
+        #"selection": selection_single_nearest
+    }
+
+    #log.info('df_melted:\n%s', df_melted)
+    #sys.exit()
+
     chart = (
         alt.Chart(df_melted)
         .mark_line(point=True)
@@ -593,8 +609,8 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
         # timeout unit transformation. Ref:
         # https://altair-viz.github.io/user_guide/transform/timeunit.html
         .encode(
-            alt.X(**x_kwargs),
-            alt.Y(
+            x=alt.X(**x_kwargs),
+            y=alt.Y(
                 "views_unique_norm",
                 type="quantitative",
                 title="unique visitors per day (mean from last 14 days)",
@@ -603,7 +619,7 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
                     zero=True,
                 ),
             ),
-            alt.Color(
+            color=alt.Color(
                 entity_type,
                 type="nominal",
                 sort=alt.SortField("order"),
@@ -615,8 +631,10 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
                     # "legendX": 120,
                     # "legendY": 340,
                     "title": "Legend:"
-                } ,
+                },
             ),
+            tooltip=entity_type
+            #opacity=alt.condition(selection_single_nearest, alt.value(1), alt.value(0.1)),
         )
         .configure_point(size=30)
         .properties(**panel_props)

--- a/analyze.py
+++ b/analyze.py
@@ -494,7 +494,7 @@ def analyse_top_x_snapshots(entity_type):
     max_vu_map = {}
     for ename, edf in entity_dfs.items():
         max_vu_map[ename] = edf["views_unique"].max()
-    del ename
+    del ename, edf
 
     # Sort dict so that the first item is the referrer/path with the highest
     # views_unique seen.
@@ -503,6 +503,16 @@ def analyse_top_x_snapshots(entity_type):
     }
 
     log.info(f'{entity_type}, highest views_unique seen: {sorted_dict}')
+
+    # log.info(entity_dfs['linkedin.com'])
+    # log.info(entity_dfs['vega.github.io'])
+    # log.info(pd.concat(
+    #     [
+    #         pd.Series(entity_dfs['linkedin.com']["views_unique"], name='linkedin_com_views_unique') ,
+    #         pd.Series(entity_dfs['vega.github.io']["views_unique"], name='vega_views_unique')
+    #     ], axis=1))
+    # sys.exit()
+
     top_n = 10
     top_n_enames = list(sorted_dict.keys())[:top_n]
 
@@ -526,6 +536,7 @@ def analyse_top_x_snapshots(entity_type):
         entity_type,
         df_top_vu,
     )
+    # sys.exit()
 
     # For plotting with Altair, reshape the data using pd.melt() to combine the
     # multiple columns into one, where the referrer name is not a column label,

--- a/analyze.py
+++ b/analyze.py
@@ -1347,7 +1347,7 @@ def parse_args():
 
     parser.add_argument(
         "snapshotdir",
-        metavar="PATH",
+        metavar="SNAPSHOT_DIR_PATH",
         help="path to directory containing CSV files of data snapshots / time series fragments, obtained via fetch.py",
     )
 

--- a/analyze.py
+++ b/analyze.py
@@ -687,7 +687,7 @@ def analyse_view_clones_ts_fragments():
     basename_suffix = "_views_clones_series_fragment.csv"
     csvpaths = _glob_csvpaths(basename_suffix)
 
-    dfs = []
+    snapshot_dfs = []
     column_names_seen = set()
 
     for p in csvpaths:
@@ -758,17 +758,17 @@ def analyse_view_clones_ts_fragments():
             )
             sys.exit(1)
 
-        dfs.append(df)
+        snapshot_dfs.append(df)
 
-    # for df in dfs:
+    # for df in snapshot_dfs:
     #     print(df)
 
-    log.info("total sample count: %s", sum(len(df) for df in dfs))
+    log.info("total sample count: %s", sum(len(df) for df in snapshot_dfs))
 
-    if len(dfs) == 0:
+    if len(snapshot_dfs) == 0:
         log.info("special case: no snapshots read for views/clones")
     else:
-        newest_snapshot_time = max(df.attrs["snapshot_time"] for df in dfs)
+        newest_snapshot_time = max(df.attrs["snapshot_time"] for df in snapshot_dfs)
         log.info("time of newest snapshot: %s", newest_snapshot_time)
 
     # Read previously created views/clones aggregate file if it exists.
@@ -788,12 +788,12 @@ def analyse_view_clones_ts_fragments():
                 ARGS.views_clones_aggregate_inpath,
             )
 
-    if len(dfs) == 0 and df_prev_agg is None:
+    if len(snapshot_dfs) == 0 and df_prev_agg is None:
         log.info("leave early: no data for views/clones: no snapshots, no previous aggregate")
         return
 
     log.info("build aggregate, drop duplicate data")
-    # Each dataframe in `dfs` corresponds to one time series fragment
+    # Each dataframe in `snapshot_dfs` corresponds to one time series fragment
     # ("snapshot") obtained from the GitHub API. Each time series fragment
     # contains 15 samples (rows), with two adjacent samples being 24 hours
     # apart. Ideally, the time series fragments overlap in time. They overlap
@@ -802,10 +802,10 @@ def analyse_view_clones_ts_fragments():
     # are expected to be "the same" as in the snapshot taken the day before).
     # Stich these fragments together (with a buch of "duplicate samples), and
     # then sort this result by time.
-    if len(dfs):
+    if len(snapshot_dfs):
         # combine all snapshots
-        log.info("pd.concat(dfs)")
-        df_allsnapshots = pd.concat(dfs)
+        log.info("pd.concat(snapshot_dfs)")
+        df_allsnapshots = pd.concat(snapshot_dfs)
 
         # Combine the result of combine-all-snapshots with previous aggregate
         dfall = df_allsnapshots


### PR DESCRIPTION
General:
- Fix #36 (snapshot time series merge)
- Views/clones analysis: do not crash when there is an aggregate file but no new snapshots.
- Sync time range across all plots shown: time window defined by oldest and newest timestamp from views/clones data.

Style:
- Reduce marker size.
- Add color coding legend for the top referrer/path
plots above the plots.
- Show date tick labels with an angle.
- Add tooltip to data points in referrer/path plot
