### PR TITLE
Fix star/fork plot axis limit, bump deps, improve logging, enhance style, misc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jgehrcke/github-repo-stats-base:9dec0ebaf
+FROM jgehrcke/github-repo-stats-base:2c3e6756a
 
 COPY fetch.py /fetch.py
 COPY analyze.py /analyze.py

--- a/analyze.py
+++ b/analyze.py
@@ -1087,19 +1087,26 @@ def analyse_view_clones_ts_fragments():
     #### Unique visitors
     <div id="chart_views_unique" class="full-width-chart"></div>
 
+    Cumulative: {df_agg_views["views_unique"].sum()}
+
     #### Total views
     <div id="chart_views_total" class="full-width-chart"></div>
 
-    <div class="pagebreak-for-print"> </div>
+    Cumulative: {df_agg_views["views_total"].sum()}
 
+    <div class="pagebreak-for-print"> </div>
 
     ## Clones
 
     #### Unique cloners
     <div id="chart_clones_unique" class="full-width-chart"></div>
 
+    Cumulative: {df_agg_clones["clones_unique"].sum()}
+
     #### Total clones
     <div id="chart_clones_total" class="full-width-chart"></div>
+
+    Cumulative: {df_agg_clones["clones_total"].sum()}
 
     """
         )

--- a/analyze.py
+++ b/analyze.py
@@ -595,7 +595,7 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
     # plot that this is a _mean_ value derived from the _last 14 days_.
     df_melted["views_unique_norm"] = df_melted["views_unique"] / 14.0
 
-    y_axis_scale_type = symlog_or_lin(df_melted, "views_unique_norm", 5)
+    y_axis_scale_type = symlog_or_lin(df_melted, "views_unique_norm", 8)
 
     x_kwargs = DATETIME_AXIS_PROPERTIES.copy()
     if date_axis_lim is not None:
@@ -945,7 +945,7 @@ def analyse_view_clones_ts_fragments():
     x_kwargs["scale"] = alt.Scale(domain=date_axis_lim)
 
     yaxis = alt.Axis()
-    yaxistype = symlog_or_lin(df_agg_clones, "clones_unique", 30)
+    yaxistype = symlog_or_lin(df_agg_clones, "clones_unique", 100)
     if yaxistype == "symlog":
         yaxis = alt.Axis(values=[1, 10, 50, 100, 500, 1000, 5000, 10000])
     chart_clones_unique = (
@@ -977,7 +977,7 @@ def analyse_view_clones_ts_fragments():
     )
 
     yaxis = alt.Axis()
-    yaxistype = symlog_or_lin(df_agg_clones, "clones_total", 30)
+    yaxistype = symlog_or_lin(df_agg_clones, "clones_total", 100)
     if yaxistype == "symlog":
         yaxis = alt.Axis(values=[1, 10, 50, 100, 500, 1000, 5000, 10000])
     chart_clones_total = (
@@ -1009,7 +1009,7 @@ def analyse_view_clones_ts_fragments():
     )
 
     yaxis = alt.Axis()
-    yaxistype = symlog_or_lin(df_agg_views, "views_unique", 30)
+    yaxistype = symlog_or_lin(df_agg_views, "views_unique", 100)
     if yaxistype == "symlog":
         yaxis = alt.Axis(values=[1, 10, 50, 100, 500, 1000, 5000, 10000])
     chart_views_unique = (
@@ -1041,7 +1041,7 @@ def analyse_view_clones_ts_fragments():
     )
 
     yaxis = alt.Axis()
-    yaxistype = symlog_or_lin(df_agg_views, "views_total", 30)
+    yaxistype = symlog_or_lin(df_agg_views, "views_total", 100)
     if yaxistype == "symlog":
         yaxis = alt.Axis(values=[1, 10, 50, 100, 500, 1000, 5000, 10000])
     chart_views_total = (

--- a/analyze.py
+++ b/analyze.py
@@ -972,7 +972,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=40)
+        .configure_point(size=20)
         .properties(**panel_props)
     )
 
@@ -1004,7 +1004,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=40)
+        .configure_point(size=20)
         .properties(**panel_props)
     )
 
@@ -1036,7 +1036,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=40)
+        .configure_point(size=20)
         .properties(**panel_props)
     )
 
@@ -1068,7 +1068,7 @@ def analyse_view_clones_ts_fragments():
             )
         )
         .configure_axisY(labelBound=True)
-        .configure_point(size=40)
+        .configure_point(size=20)
         .properties(**panel_props)
     )
 

--- a/analyze.py
+++ b/analyze.py
@@ -24,6 +24,7 @@ import shutil
 import sys
 import tempfile
 
+from typing import List, Set
 from datetime import datetime
 from io import StringIO
 
@@ -59,7 +60,7 @@ ARGS = None
 # Individual code sections are supposed to add to this in-memory Markdown
 # document as they desire.
 MD_REPORT = StringIO()
-JS_FOOTER_LINES = []
+JS_FOOTER_LINES: List[str] = []
 
 # https://github.com/vega/vega-embed#options -- use SVG renderer so that PDF
 # export (print) from browser view yields arbitrarily scalable (vector)
@@ -697,7 +698,7 @@ def analyse_top_x_snapshots(entity_type, date_axis_lim):
     )
 
 
-def analyse_view_clones_ts_fragments():
+def analyse_view_clones_ts_fragments() -> pd.DataFrame:
 
     log.info("read views/clones time series fragments (CSV docs)")
 
@@ -705,7 +706,7 @@ def analyse_view_clones_ts_fragments():
     csvpaths = _glob_csvpaths(basename_suffix)
 
     snapshot_dfs = []
-    column_names_seen = set()
+    column_names_seen: Set[str] = set()
 
     for p in csvpaths:
         log.info("attempt to parse %s", p)
@@ -1263,7 +1264,7 @@ def symlog_or_lin(df, colname, threshold):
     return "linear"
 
 
-def get_stars_over_time():
+def get_stars_over_time() -> pd.DataFrame:
     # TODO: for ~10k stars repositories, this operation is too costly for doing
     # it as part of each analyzer invocation. Move this to the fetcher, and
     # persist the data.
@@ -1350,7 +1351,7 @@ def get_stars_over_time():
     return df
 
 
-def get_forks_over_time():
+def get_forks_over_time() -> pd.DataFrame:
     # TODO: for ~10k forks repositories, this operation is too costly for doing
     # it as part of each analyzer invocation. Move this to the fetcher, and
     # persist the data.

--- a/analyze.py
+++ b/analyze.py
@@ -1079,7 +1079,7 @@ def analyse_view_clones_ts_fragments():
 
     MD_REPORT.write(
         textwrap.dedent(
-            """
+            f"""
 
 
     ## Views

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -9,5 +9,5 @@ RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" 
 RUN apt-get -y update
 RUN apt-get -y install google-chrome-stable
 
-RUN pip install pandas==1.3.2 PyGitHub==1.54.1 pytz retrying \
-    selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.1.0
+RUN pip install pandas==1.3.4 PyGitHub==1.55 pytz retrying \
+    selenium==3.141.0 webdriver_manager carbonplan[styles] altair==4.2.0rc1


### PR DESCRIPTION
- Use Altair 4.2.0rc1 which uses Vega-Lite 4.17.0.
- Use Pandas 1.3.4

- Reduce log verbosity (no more INFO msg per snapshot file)

- Fix time boundary for star/fork plots: the star/fork plots always show the same time window. However, a star/fork plot only shows the same time window as the view/clone plots when collection started at the time of or before the first star/fork event.

- Tweak lin/log threshold
- Display cumulative view/clone counts
- Enhance plot style