### PR TITLE
bug: Fix date axis lim computation when repo has no stargazers or no forks

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -107,12 +107,13 @@ def main():
     # before the first sg/fork event having happened is also possible. That is,
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
-    if len(df_stargazers) or len(df_forks):
+    if len(df_stargazers.index.values) or len(df_forks.index.values):
         dfs = list(df_vc_agg)
-        if len(df_stargazers):
+        if len(df_stargazers.index.values):
             dfs.append(df_stargazers)
-        if len(df_forks):
+        if len(df_forks.index.values):
             dfs.append(df_forks)
+        log.info("datagrames for stargazer/fork time window: %s", dfs)
         sf_date_axis_lim = gen_date_axis_lim(tuple(dfs))
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 

--- a/analyze.py
+++ b/analyze.py
@@ -113,7 +113,6 @@ def main():
             dfs = dfs + (df_stargazers,)
         if len(df_forks.index.values):
             dfs = dfs + (df_forks,)
-        log.info("dataframes for stargazer/fork time window: %s", dfs)
         sf_date_axis_lim = gen_date_axis_lim(dfs)
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 

--- a/analyze.py
+++ b/analyze.py
@@ -108,13 +108,13 @@ def main():
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
     if len(df_stargazers.index.values) or len(df_forks.index.values):
-        dfs = list(df_vc_agg)
+        dfs = (df_vc_agg,)
         if len(df_stargazers.index.values):
-            dfs.append(df_stargazers)
+            dfs = dfs + (df_stargazers,)
         if len(df_forks.index.values):
-            dfs.append(df_forks)
-        log.info("datagrames for stargazer/fork time window: %s", dfs)
-        sf_date_axis_lim = gen_date_axis_lim(tuple(dfs))
+            dfs = dfs + (df_forks,)
+        log.info("dataframes for stargazer/fork time window: %s", dfs)
+        sf_date_axis_lim = gen_date_axis_lim(dfs)
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
         sf_starts_earlier_than_vc_data = (

--- a/analyze.py
+++ b/analyze.py
@@ -107,7 +107,7 @@ def main():
     # before the first sg/fork event having happened is also possible. That is,
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
-    sf_date_axis_lim = gen_date_axis_lim((df_vc_agg, df_stargazers, df_forks))
+    sf_date_axis_lim = gen_date_axis_lim(filter(lambda df: len(df.index.values) > 0, (df_vc_agg, df_stargazers, df_forks)))
     log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
     sf_starts_earlier_than_vc_data = (

--- a/analyze.py
+++ b/analyze.py
@@ -120,16 +120,10 @@ def main():
         sf_starts_earlier_than_vc_data = False
 
         if len(df_stargazers) and len(df_stargazers.index.values):
-            sf_starts_earlier_than_vc_data = (
-                    min(df_stargazers.index.values.min())
-                    < df_vc_agg.index.values.min()
-            )
+            sf_starts_earlier_than_vc_data = (df_stargazers.index.values.min() < df_vc_agg.index.values.min())
 
         if not sf_starts_earlier_than_vc_data and len(df_forks) and len(df_forks.index.values):
-            sf_starts_earlier_than_vc_data = (
-                    min(df_forks.index.values.min())
-                    < df_vc_agg.index.values.min()
-            )
+            sf_starts_earlier_than_vc_data = (df_forks.index.values.min() < df_vc_agg.index.values.min())
 
         if len(df_stargazers):
             add_stargazers_section(

--- a/analyze.py
+++ b/analyze.py
@@ -107,7 +107,7 @@ def main():
     # before the first sg/fork event having happened is also possible. That is,
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
-    if len(df_stargazers.index.values) or len(df_forks.index.values):
+    if len(df_vc_agg) and len(df_vc_agg.index.values) and (len(df_stargazers) or len(df_forks)):
         dfs = (df_vc_agg,)
         if len(df_stargazers.index.values):
             dfs = dfs + (df_stargazers,)

--- a/analyze.py
+++ b/analyze.py
@@ -107,8 +107,13 @@ def main():
     # before the first sg/fork event having happened is also possible. That is,
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
-    if len(df_stargazers) or len(df_stargazers):
-        sf_date_axis_lim = gen_date_axis_lim(filter(lambda df: len(df), (df_vc_agg, df_stargazers, df_forks)))
+    if len(df_stargazers) or len(df_forks):
+        dfs = list(df_vc_agg)
+        if len(df_stargazers):
+            dfs.append(df_stargazers)
+        if len(df_forks):
+            dfs.append(df_forks)
+        sf_date_axis_lim = gen_date_axis_lim(dfs)
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
         sf_starts_earlier_than_vc_data = (

--- a/analyze.py
+++ b/analyze.py
@@ -107,21 +107,24 @@ def main():
     # before the first sg/fork event having happened is also possible. That is,
     # extract min and max timestamps from all available time series data:
     # views/clones, sg, forks).
-    sf_date_axis_lim = gen_date_axis_lim(filter(lambda df: len(df.index.values) > 0, (df_vc_agg, df_stargazers, df_forks)))
-    log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
+    if len(df_stargazers) or len(df_stargazers):
+        sf_date_axis_lim = gen_date_axis_lim(filter(lambda df: len(df), (df_vc_agg, df_stargazers, df_forks)))
+        log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
-    sf_starts_earlier_than_vc_data = (
-        min(df_stargazers.index.values.min(), df_forks.index.values.min())
-        < df_vc_agg.index.values.min()
-    )
-
-    if len(df_stargazers):
-        add_stargazers_section(
-            df_stargazers, sf_date_axis_lim, sf_starts_earlier_than_vc_data
+        sf_starts_earlier_than_vc_data = (
+            min(df_stargazers.index.values.min(), df_forks.index.values.min())
+            < df_vc_agg.index.values.min()
         )
 
-    if len(df_forks):
-        add_fork_section(df_forks, sf_date_axis_lim, sf_starts_earlier_than_vc_data)
+        if len(df_stargazers):
+            add_stargazers_section(
+                df_stargazers, sf_date_axis_lim, sf_starts_earlier_than_vc_data
+            )
+
+        if len(df_forks):
+            add_fork_section(
+                df_forks, sf_date_axis_lim, sf_starts_earlier_than_vc_data
+            )
 
     report_pdf_pagebreak()
 

--- a/analyze.py
+++ b/analyze.py
@@ -113,7 +113,7 @@ def main():
             dfs.append(df_stargazers)
         if len(df_forks):
             dfs.append(df_forks)
-        sf_date_axis_lim = gen_date_axis_lim(dfs)
+        sf_date_axis_lim = gen_date_axis_lim(tuple(dfs))
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
         sf_starts_earlier_than_vc_data = (

--- a/analyze.py
+++ b/analyze.py
@@ -117,10 +117,19 @@ def main():
         sf_date_axis_lim = gen_date_axis_lim(dfs)
         log.info("time window for stargazer/fork data: %s", sf_date_axis_lim)
 
-        sf_starts_earlier_than_vc_data = (
-            min(df_stargazers.index.values.min(), df_forks.index.values.min())
-            < df_vc_agg.index.values.min()
-        )
+        sf_starts_earlier_than_vc_data = False
+
+        if len(df_stargazers) and len(df_stargazers.index.values):
+            sf_starts_earlier_than_vc_data = (
+                    min(df_stargazers.index.values.min())
+                    < df_vc_agg.index.values.min()
+            )
+
+        if not sf_starts_earlier_than_vc_data and len(df_forks) and len(df_forks.index.values):
+            sf_starts_earlier_than_vc_data = (
+                    min(df_forks.index.values.min())
+                    < df_vc_agg.index.values.min()
+            )
 
         if len(df_stargazers):
             add_stargazers_section(


### PR DESCRIPTION
Greetings!

After seeing your update on #28 (thanks btw!) I decided to give it a try by using `@main` in my workflow action.

I ended up with the following error:
```
Traceback (most recent call last):
  File "/analyze.py", line 1588, in <module>
    main()
  File "/analyze.py", line 110, in main
    sf_date_axis_lim = gen_date_axis_lim((df_vc_agg, df_stargazers, df_forks))
  File "/analyze.py", line 159, in gen_date_axis_lim
    pd.to_datetime(min(df.index.values[0] for df in dfs)).strftime("%Y-%m-%d"),
  File "/analyze.py", line 159, in <genexpr>
    pd.to_datetime(min(df.index.values[0] for df in dfs)).strftime("%Y-%m-%d"),
IndexError: index 0 is out of bounds for axis 0 with size 0
```

I actually received this error on 3 repos (using the matrix method), all of which happen to have 0 (zero) forks.

I put together this PR to try to correct for repos with no stargazers or no forks.

NOTES:

* I've enabled "Allow edits by maintainers"

* I'm not tied to any part of the code, so please feel free to make any suggests you like.

* I'm not a pythoner, and I tested the code inside the workflow, so it took several commits to get everything working.  PLEASE consider squash-merging if/when this gets merged.

-DF

