### PR TITLE
entrypoint.sh: add report.pdf blob link (#74)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -234,6 +234,10 @@ cat << EOF > README.md
 - workflow that created this README: \`${GITHUB_WORKFLOW}\`
 
 **Latest report PDF**: [report.pdf](https://github.com/${DATA_REPOSPEC}/raw/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf)
+- Depending on your browser, either opens in the browser or downloads the file
+
+**Latest report PDF in GitHub UI**: [report.pdf](https://github.com/${DATA_REPOSPEC}/blob/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf)
+- Opens in the browser
 
 EOF
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -233,11 +233,7 @@ cat << EOF > README.md
 - managed by GitHub Action: https://github.com/jgehrcke/github-repo-stats
 - workflow that created this README: \`${GITHUB_WORKFLOW}\`
 
-**Latest report PDF**: [report.pdf](https://github.com/${DATA_REPOSPEC}/raw/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf)
-- Depending on your browser, either opens in the browser or downloads the file
-
-**Latest report PDF in GitHub UI**: [report.pdf](https://github.com/${DATA_REPOSPEC}/blob/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf)
-- Opens in the browser
+**Latest report PDF**: [GitHub-rendered](https://github.com/${DATA_REPOSPEC}/blob/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf), [raw](https://github.com/${DATA_REPOSPEC}/raw/${DATA_BRANCH_NAME}/${STATS_REPOSPEC}/latest-report/report.pdf)
 
 EOF
 


### PR DESCRIPTION
- For #74

I had time right now, so made the change without waiting for your response to the issue. Feel free to close this PR if the change doesn't interest you!

&nbsp;

Adds a link to READMEs which opens the latest report pdf in the browser, even in Chromium browsers and Safari.

The change I made is conservative. It leaves the existing "latest report pdf" line untouched, to not trip up users who like its behavior. I can also imagine a less conservative change, something like

```
**Latest report**
- [raw PDF]() Depending on your browser, either opens in the browser or downloads the file
- [PDF in GitHub UI]() Opens in the browser
```

Happy to make adjustments