### PR TITLE
fix: Use utcyearmonthdate to prevent off-by-one day in charts for UTC-N timezones

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -74,7 +74,7 @@ DATETIME_AXIS_PROPERTIES = {
     "field": "time",
     "type": "temporal",
     "title": "date",
-    "timeUnit": "yearmonthdate",
+    "timeUnit": "utcyearmonthdate",       # ← UTC prevents off-by-one for negative UTC offsets
     "axis": {"labelAngle": DATE_LABEL_ANGLE},
 }
 

--- a/analyze.py
+++ b/analyze.py
@@ -74,7 +74,7 @@ DATETIME_AXIS_PROPERTIES = {
     "field": "time",
     "type": "temporal",
     "title": "date",
-    "timeUnit": "utcyearmonthdate",       # ← UTC prevents off-by-one for negative UTC offsets
+    "timeUnit": "utcyearmonthdate",
     "axis": {"labelAngle": DATE_LABEL_ANGLE},
 }
 


### PR DESCRIPTION
Fixes #87 

Vega-Lite's yearmonthdate `timeUnit` renders timestamps in the browser's local timezone. For users in UTC-N time zones (e.g., UTC-5), a data point timestamped at 2024-01-09 00:00:00+00:00 (midnight UTC) is converted to the previous day in local time and then binned there, producing a spurious data point one day before the first real sample.

Changing to `utcyearmonthdate` forces UTC rendering, which matches the UTC timestamps stored in the CSV data.

<img width="2023" height="774" alt="image" src="https://github.com/user-attachments/assets/75840d2a-fa52-4c9f-a4b7-e739d4da6732" />

@jgehrcke, thanks for the great tool!